### PR TITLE
chore: `write_node` doesn't need mut reference

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -406,9 +406,6 @@ impl<'file, const SIZE: usize> WriteBuffer<'file, SIZE> {
         };
 
         self.len += size;
-        if self.len >= SIZE {
-            self.flush()?;
-        }
         Ok(node_id)
     }
 }


### PR DESCRIPTION
Initially I thought `mem_size` may under-estimate. But later I found if it happens, `encode_into_slice` will fail first. So only leaving two trivial changes.