### PR TITLE
simplify by: `depth + prefix.bit_len()== point`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 extern crate alloc;
 
 pub mod path;
+#[cfg(test)]
+pub mod path_test;
 pub mod subtree;
 
 #[cfg(feature = "std")]

--- a/src/path_test.rs
+++ b/src/path_test.rs
@@ -1,0 +1,19 @@
+use crate::path::{BitLength, Path, PathSegment};
+use crate::ZERO_HASH;
+
+#[test]
+fn path_bit_len() {
+    let current_key = Path(ZERO_HASH);
+    for depth in 0..256 {
+        for point in depth..256 {
+            let seg = PathSegment::from_path(current_key, depth, point);
+            assert_eq!(
+                seg.bit_len(),
+                point - depth,
+                "depth:{} point:{}",
+                depth,
+                point
+            );
+        }
+    }
+}

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -361,7 +361,7 @@ impl<'db, H: NodeHasher> WriteTransaction<'db, H> {
         let point = current_key.split_point(0, key).unwrap();
         let prefix = PathSegment::from_path(current_key, depth, point);
 
-        let depth = depth + prefix.bit_len();
+        let depth = point;
         let node_direction = key.direction(depth);
         let current_node = Node::from_leaf(current_key, current_value);
         let node = Node::from_leaf(key, value);


### PR DESCRIPTION
The test shows `bit_len() == point - depth` is always true as long as `point > depth`.

So `depth + prefix.bit_len()` is the same as `depth + point - depth`, which is `depth`.