### PR TITLE
fix stack overflow of tests

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -306,7 +306,7 @@ impl StorageBackend for MemoryBackend {
 
 pub struct WriteBuffer<'file, const SIZE: usize> {
     file: &'file Box<dyn StorageBackend>,
-    buffer: [u8; SIZE],
+    buffer: Box<[u8; SIZE]>,
     len: usize,
     file_len: u64,
 }
@@ -315,7 +315,7 @@ impl<'file, const SIZE: usize> WriteBuffer<'file, SIZE> {
     pub(crate) fn new(file: &'file Box<dyn StorageBackend>, file_len: u64) -> Self {
         Self {
             file,
-            buffer: [0u8; SIZE],
+            buffer: [0u8; SIZE].into(),
             len: 0,
             file_len,
         }


### PR DESCRIPTION
Currently only the first test will pass, others will report stack overflow.

It can be worked around by setting larger `RUST_MIN_STACK` but it's inconvenient.

This pr fixes this issue by making `WriteBuffer` allocate on heap instead of stack.