### PR TITLE
Extended Proofs & Delete operation support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ libc = { version = "0.2.150", optional = true }
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc"] }
 hex = { version = "0.4.3", optional = true }
 
+[dev-dependencies]
+rand = "0.8.5"
+
 [dependencies.sha2]
 git = "https://github.com/risc0/RustCrypto-hashes"
 tag = "sha2-v0.10.6-risczero.0"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let keys_to_prove: Vec<_> = (0..10)
     .collect();
 
 // Reveal relevant nodes needed to prove the specified set of keys
-let mut subtree = snapshot.prove(&keys_to_prove)?;
+let mut subtree = snapshot.prove(&keys_to_prove, ProofType::Standard)?;
 
 // Will have the exact same root as the snapshot
 println!("Subtree root: {}", hex::encode(subtree.root().unwrap()));

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let keys_to_prove: Vec<_> = (0..10)
     .collect();
 
 // Reveal relevant nodes needed to prove the specified set of keys
-let mut subtree = snapshot.prove_all(&keys_to_prove)?;
+let mut subtree = snapshot.prove(&keys_to_prove)?;
 
 // Will have the exact same root as the snapshot
 println!("Subtree root: {}", hex::encode(subtree.root().unwrap()));

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
         .collect();
 
     // reveal the relevant nodes needed to prove the specified set of keys
-    let subtree = snapshot.prove_all(&keys_to_prove)?;
+    let subtree = snapshot.prove(&keys_to_prove)?;
 
     // Will have the exact same root as the snapshot
     println!("Subtree root: {}", hex::encode(subtree.root().unwrap()));

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,6 +1,6 @@
-use spacedb::db::Database;
+use spacedb::{Result, db::Database };
 
-fn main() -> Result<(), std::io::Error> {
+fn main() -> Result<()> {
     let db = Database::memory()?;
 
     // Insert some data

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,4 +1,5 @@
 use spacedb::{Result, db::Database };
+use spacedb::tx::ProofType;
 
 fn main() -> Result<()> {
     let db = Database::memory()?;
@@ -25,7 +26,7 @@ fn main() -> Result<()> {
         .collect();
 
     // reveal the relevant nodes needed to prove the specified set of keys
-    let subtree = snapshot.prove(&keys_to_prove)?;
+    let subtree = snapshot.prove(&keys_to_prove, ProofType::Standard)?;
 
     // Will have the exact same root as the snapshot
     println!("Subtree root: {}", hex::encode(subtree.root().unwrap()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,30 @@ pub enum Error {
     Verify(VerifyError),
 }
 
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            #[cfg(feature = "std")]
+            Error::IO(err) => write!(f, "IO error: {}", err),
+            Error::Verify(err) => write!(f, "Verification error: {}", err),
+        }
+    }
+}
+
+impl core::fmt::Display for VerifyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        match self {
+            VerifyError::KeyExists => write!(f, "Key already exists"),
+            VerifyError::IncompleteProof => write!(f, "Incomplete proof"),
+            VerifyError::KeyNotFound => write!(f, "Key not found"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+
 #[derive(Debug)]
 pub enum VerifyError {
     KeyExists,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,21 @@ pub mod fs;
 #[cfg(feature = "std")]
 pub(crate) const ZERO_HASH: Hash = [0; 32];
 
+pub type Result<T> = core::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    #[cfg(feature = "std")]
+    IO(std::io::Error),
+    Verify(VerifyError),
+}
+
+#[derive(Debug)]
+pub enum VerifyError {
+    KeyExists,
+    IncompleteProof,
+}
+
 use core::marker::PhantomData;
 use sha2::{Digest as _, Sha256};
 
@@ -90,5 +105,25 @@ impl NodeHasher for Sha256Hasher {
         hasher.update(right);
 
         hasher.finalize().as_slice().try_into().unwrap()
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error::IO(err)
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::ErrorKind> for Error {
+    fn from(kind: std::io::ErrorKind) -> Self {
+        Error::IO(std::io::Error::from(kind))
+    }
+}
+
+impl From<VerifyError> for Error {
+    fn from(err: VerifyError) -> Self {
+        Error::Verify(err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,6 @@ pub mod tx;
 #[cfg(feature = "std")]
 pub mod fs;
 
-#[cfg(feature = "std")]
-pub(crate) const ZERO_HASH: Hash = [0; 32];
-
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(Debug)]
@@ -32,6 +29,7 @@ pub enum Error {
 pub enum VerifyError {
     KeyExists,
     IncompleteProof,
+    KeyNotFound,
 }
 
 use core::marker::PhantomData;

--- a/src/path.rs
+++ b/src/path.rs
@@ -97,6 +97,24 @@ impl<T: AsMut<[u8]>> PathSegment<T> {
         }
     }
 
+    /// Extend from another path segment
+    pub fn extend<A: BitLength + PathUtils>(&mut self, other: A) {
+        let inner = other.inner();
+
+        let mut remaining_bits = other.bit_len();
+        let mut index = 0;
+
+        while remaining_bits >= 8 {
+            self.extend_from_byte(inner[index], 8);
+            remaining_bits -= 8;
+            index += 1;
+        }
+
+        if remaining_bits > 0 {
+            self.extend_from_byte(inner[index], remaining_bits as u8);
+        }
+    }
+
     /// Extends the current path with bits from a single byte.
     ///
     /// This function takes a byte `bits` and a length `len` and extends the current path with the specified

--- a/src/path.rs
+++ b/src/path.rs
@@ -97,6 +97,52 @@ impl<T: AsMut<[u8]>> PathSegment<T> {
         }
     }
 
+    /// Extends the current path with bits from a single byte.
+    ///
+    /// This function takes a byte `bits` and a length `len` and extends the current path with the specified
+    /// number of bits.
+    ///
+    /// # Arguments
+    ///
+    /// * `bits` - The byte containing the bits to extend.
+    /// * `len` - The number of bits to extend from the byte (must be less than or equal to 8).
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `len` is greater than 8 or not enough space
+    /// to accommodate the new bits.
+    pub fn extend_from_byte(&mut self, bits: u8, len: u8) {
+        assert!(len <= 8, "invalid bit length");
+
+        let raw = self.as_mut();
+        let current_bit_len = raw[0];
+        let new_bit_len = current_bit_len + len;
+
+        raw[0] = new_bit_len;
+        let inner = &mut raw[1..];
+
+        // Get the number of remaining bit slots in the byte array
+        // If the current bit length is a multiple of 8, this will just be 8-bits.
+        let remaining_slots = 8 - (current_bit_len % 8);
+
+        // If multiples of 8, index will point to the next unfilled byte,
+        // otherwise it will point to the last partially filled byte.
+        let mut index = (current_bit_len / 8) as usize;
+
+        // We have to fill the remaining slots in the existing byte
+        if len <= remaining_slots {
+            inner[index] |= bits >> (8 - len) << (remaining_slots - len);
+        } else {
+            inner[index] |= bits >> (8 - remaining_slots);
+
+            // carry over any remaining bits to a new byte
+            index += 1;
+            let remaining_bits = len - remaining_slots;
+            assert!(inner.len() > index, "not enough space");
+            inner[index] = bits >> (8 - remaining_bits) << remaining_slots;
+        }
+    }
+
     #[inline(always)]
     pub fn set_len(&mut self, len: usize) {
         assert!(len <= 255, "PathSegment length must be <= 255");
@@ -253,4 +299,52 @@ pub trait BitLength {
     fn bit_len(&self) -> usize;
     fn inner(&self) -> &[u8];
     fn as_bytes(&self) -> &[u8];
+}
+
+
+#[cfg(test)]
+mod tests {
+    use core::fmt::Display;
+    use crate::path::{BitLength, Direction, PathSegment, PathUtils};
+
+    impl<T: AsRef<[u8]>> Display for PathSegment<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            for i in 0..self.bit_len() {
+                if self.direction(i) == Direction::Right {
+                    write!(f, "1")?;
+                } else {
+                    write!(f, "0")?;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_extend_from_byte() {
+        let mut segment = PathSegment([0u8;33]);
+        segment.set_len(2);
+
+        let inner = segment.as_mut_inner();
+        inner[0] = 0b1100_0000;
+
+        segment.extend_from_byte(0b1000_1000,3);
+        assert_eq!(segment.to_string(), "11100");
+
+        segment.extend_from_byte(0b1111_1111, 8);
+        assert_eq!(segment.to_string(), "1110011111111");
+
+        segment.extend_from_byte(0b0011_1111, 2);
+        assert_eq!(segment.to_string(), "111001111111100");
+
+        segment.extend_from_byte(0b1111_1111, 8);
+        assert_eq!(segment.to_string(), "11100111111110011111111");
+
+        segment.extend_from_byte(0b0000_1111, 4);
+        assert_eq!(segment.to_string(), "111001111111100111111110000");
+
+        segment.set_len(segment.bit_len() + 2);
+        assert_eq!(segment.to_string(),  "11100111111110011111111000000",
+                   "trailing bits must be cleared");
+    }
 }

--- a/src/subtree.rs
+++ b/src/subtree.rs
@@ -233,6 +233,12 @@ impl<H: NodeHasher> SubTree<H> {
     }
 }
 
+impl SubTreeNode {
+    pub fn is_value_leaf(&self) -> bool {
+        matches!(self, SubTreeNode::Leaf {  value_or_hash: ValueOrHash::Value(_), ..})
+    }
+}
+
 impl<H: NodeHasher> Encode for SubTree<H> {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> core::result::Result<(), EncodeError> {
         Encode::encode(&self.root, encoder)

--- a/src/subtree.rs
+++ b/src/subtree.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use alloc::{boxed::Box, vec, vec::Vec};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 use bincode::{
     de::Decoder,
     enc::Encoder,

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -82,11 +82,7 @@ impl<'db, H: NodeHasher + 'db> ReadTransaction<'db, H> {
         Ok(h)
     }
 
-    pub fn prove(&mut self, key: &Hash) -> Result<SubTree<H>> {
-        self.prove_all(&[*key])
-    }
-
-    pub fn prove_all(&mut self, keys: &[Hash]) -> Result<SubTree<H>> {
+    pub fn prove(&mut self, keys: &[Hash]) -> Result<SubTree<H>> {
         let mut node = self.cache.node.take().unwrap();
         if node.id == EMPTY_RECORD {
             self.cache.node = Some(node);

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -16,7 +16,6 @@ use crate::{db::DatabaseHeader, fs::WriteBuffer};
 
 use crate::{
     path::{PathSegment, PathSegmentInner},
-    ZERO_HASH,
 };
 
 const BUFFER_SIZE: usize = 16 * 64 * 1024;
@@ -439,11 +438,6 @@ impl<'db, H: NodeHasher> WriteTransaction<'db, H> {
         value: Vec<u8>,
         depth: usize,
     ) -> Result<Node> {
-        // Empty root: leaf becomes root
-        if current_key == Path(ZERO_HASH) {
-            return Ok(Node::from_leaf(key, value));
-        }
-
         // Same key: update value
         if current_key == key {
             return Ok(Node::from_leaf(key, value));

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -130,7 +130,7 @@ fn get_returns_error_when_key_not_exists() {
     tx.commit().unwrap();
 
     let mut tree = db.begin_read().unwrap();
-    assert_eq!(tree.get(&key.clone()).unwrap(), value);
+    assert_eq!(tree.get(&key.clone()).unwrap(), Some(value));
     let non_existing_key = db.hash(&[1]);
-    assert_eq!(tree.get(&non_existing_key.clone()).is_err(), true);
+    assert!(tree.get(&non_existing_key.clone()).unwrap().is_none());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -13,7 +13,7 @@ fn it_works_with_empty_trees() {
     assert_eq!(root, db.hash(&[]), "empty tree must return zero hash");
 
     let foo = db.hash("foo".as_bytes());
-    let subtree = snapshot.prove(&foo).unwrap();
+    let subtree = snapshot.prove(&[foo]).unwrap();
 
     assert_eq!(
         subtree.root().unwrap(),
@@ -69,7 +69,7 @@ fn it_inserts_many_items_into_tree() {
     tx.commit().unwrap();
 
     let mut tree = db.begin_read().unwrap();
-    let subtree2 = tree.prove_all(&keys).unwrap();
+    let subtree2 = tree.prove(&keys).unwrap();
 
     assert_eq!(
         subtree2.root().unwrap(),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,6 +3,7 @@ use spacedb::{
     subtree::{SubTree, ValueOrHash},
     NodeHasher, Sha256Hasher,
 };
+use spacedb::tx::ProofType;
 
 #[test]
 fn it_works_with_empty_trees() {
@@ -13,7 +14,7 @@ fn it_works_with_empty_trees() {
     assert_eq!(root, db.hash(&[]), "empty tree must return zero hash");
 
     let foo = db.hash("foo".as_bytes());
-    let subtree = snapshot.prove(&[foo]).unwrap();
+    let subtree = snapshot.prove(&[foo], ProofType::Standard).unwrap();
 
     assert_eq!(
         subtree.root().unwrap(),
@@ -69,7 +70,7 @@ fn it_inserts_many_items_into_tree() {
     tx.commit().unwrap();
 
     let mut tree = db.begin_read().unwrap();
-    let subtree2 = tree.prove(&keys).unwrap();
+    let subtree2 = tree.prove(&keys, ProofType::Standard).unwrap();
 
     assert_eq!(
         subtree2.root().unwrap(),


### PR DESCRIPTION
Previously, the accumulator didn't support deletions which is necessary for some use cases such as representing either a subset of the Bitcoin UTXO set or the entire set (acting as an alternative to Utreexo). In addition, it enables spacedb to be used for creating priority queues for the pre-auctions pool.

This PR does the following:

1. **Extended proofs**: We need to reveal more information about the siblings of the `keys` or `nodes` that we're trying to remove since we have to correctly lift the sibling node into the parent's position. This PR introduces `ProofType::Extended` for such purposes and `ProofType::Standard` for the smaller proofs that don't require this information.
```rust
let mut subtree = snapshot.prove(vec![key1, key2, ...], ProofType::Standard)?;
let mut subtree2 = snapshot.prove(vec![key20, key40], ProofType::Extended)?;
```

It should even be possible to have more granularity over this by merging the subtrees e.g. proving some using `Standard` and some using `Extended`.

2. **Support `delete` in `WriteTransaction`**: This adds support for the delete operation in the main tree.
3. **Accumulator `delete` on subtrees**: With proofs being type `Extended`, the accumulator can correctly update the state of the subtree. If more branches/nodes need to be revealed it will fail with `IncompleteProof` error.
4. **Refactoring**: Various clean ups e.g. removing `prove` and replacing it with `prove_all`, updating `get` signature,  adding path extension utilities ... etc.


Will merge this once I do some additional testing