### PR TITLE
Add metadata and rollback functionality to snapshots

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -98,7 +98,7 @@ impl DatabaseHeader {
         }
 
         let chunks_required = (self.savepoint.len() + CHUNK_SIZE - 1) / CHUNK_SIZE;
-        chunks_required * CHUNK_SIZE
+        std::cmp::max(chunks_required * CHUNK_SIZE, HEADER_SIZE)
     }
 }
 
@@ -200,9 +200,9 @@ impl<H: NodeHasher> Database<H> {
     }
 
     pub fn begin_read(&self) -> Result<ReadTransaction<H>> {
-        let result = Self::recover_header(&self.file)?;
+        let (header, _) = Self::recover_header(&self.file)?;
         // Use the stored configuration
-        Ok(ReadTransaction::new(self.clone(), result.0.savepoint))
+        Ok(ReadTransaction::new(self.clone(), header.savepoint))
     }
 
     pub(crate) fn load_node(&self, id: Record) -> Result<NodeInner> {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -12,7 +12,7 @@ use std::{
     sync::*,
 };
 
-pub trait StorageBackend {
+pub trait StorageBackend: Sync + Send {
     fn len(&self) -> Result<u64, io::Error>;
     fn set_len(&self, len: u64) -> Result<(), io::Error>;
     fn read(&self, offset: u64, len: usize) -> Result<Vec<u8>, io::Error>;

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -364,7 +364,7 @@ impl<'db, H: NodeHasher> WriteTransaction<'db, H> {
         }
     }
 
-    pub fn set_metadata(&mut self, metadata: Vec<u8>) -> Result<()> {
+    pub fn metadata(&mut self, metadata: Vec<u8>) -> Result<()> {
         if metadata.len() > 512 {
             return Err(io::Error::new(io::ErrorKind::Other, "metadata must not exceed 512 bytes").into());
         }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -244,7 +244,7 @@ fn it_should_delete_elements_from_subtree() {
 fn it_should_store_metadata() {
     let db = Database::memory().unwrap();
     let mut tx = db.begin_write().unwrap();
-    tx.set_metadata("snapshot 0".as_bytes().to_vec()).unwrap();
+    tx.metadata("snapshot 0".as_bytes().to_vec()).unwrap();
     tx.commit().unwrap();
 
     let snapshot = db.begin_read().unwrap();
@@ -256,7 +256,7 @@ fn it_should_store_metadata() {
         let value = format!("data{}", i).as_bytes().to_vec();
         tx.insert(key, value.clone()).unwrap();
     }
-    tx.set_metadata("snapshot 1".as_bytes().to_vec()).unwrap();
+    tx.metadata("snapshot 1".as_bytes().to_vec()).unwrap();
     tx.commit().unwrap();
 
     let snapshot = db.begin_read().unwrap();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -121,6 +121,9 @@ fn it_should_iterate_over_tree() {
 #[test]
 fn it_returns_none_when_key_not_exists() {
     let db = Database::memory().unwrap();
+    let mut snapshot = db.begin_read().unwrap();
+    assert_eq!(snapshot.get(&[0u8; 32]).unwrap(), None, "empty tree should return none");
+
     let mut tx = db.begin_write().unwrap();
     let key = db.hash(&[]);
     let value = "some data".as_bytes().to_vec();


### PR DESCRIPTION
This PR adds support for the following:

### Metadata

It's now possible to attach some metadata to snapshots. This is very helpful when syncing the protocol state as `spaced` can reference block height, tree roots, or any other state data directly in the snapshot and roll back when necessary during re-orgs, etc.

```rust
let mut tx = db.begin_write()?;

// do changes here
tx.insert(.., ...)?;
tx.delete(...)?;

// Metadata takes a Vec<u8>, so it can be any serialized data
tx.metadata(some_metadata);

tx.commit()?;
```

### Rollback

Snapshots can now be rolled back to restore the database to a previous state.


```rust
for snapshot in db.iter() {
    // restore database to current snapshot
    if let Err(e) = snapshot.rollback() {
        // handle the error
    }
}
```


* This PR also updates `ReadTransaction` to take an owned reference of the database, making it easier to clone and pass to other threads without relying on locking. 

* `StorageBackend` now requires the `Sync + Send` traits to ensure thread safety when used across multiple threads.

Will do some additional testing before merging this PR