### PR TITLE
Wasm bindings for subtrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.png
 .idea
 *.sdb
+pkg

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,25 +2,32 @@ workspace = { members = ["example"] }
 
 [package]
 name = "spacedb"
-version = "0.0.2"
+version = "0.0.4"
 edition = "2021"
 description = "A cryptographically verifiable data store and universal accumulator for the Spaces protocol."
 repository = "https://github.com/spacesprotocol/spacedb"
 license = "Apache-2.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 
 [dependencies]
 libc = { version = "0.2.150", optional = true }
 bincode = { version = "2.0.0-rc.3", default-features = false, features = ["alloc"] }
 hex = { version = "0.4.3", optional = true }
 
+# optional wasm feature
+wasm-bindgen = { version ="0.2.100", optional = true }
+js-sys = { version = "0.3.77", optional = true }
+
 [dev-dependencies]
 rand = "0.8.5"
 
 [dependencies.sha2]
-git = "https://github.com/risc0/RustCrypto-hashes"
-tag = "sha2-v0.10.6-risczero.0"
-default-features = false
+version = "0.11.0-pre.4"
 
 [features]
 default = ["std"]
 std = ["libc", "hex", "bincode/derive", "bincode/std"]
+wasm = ["wasm-bindgen", "js-sys"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,28 @@ spacedb = { version = "0.1", default-features = false }
 ```
 
 
+## Using Subtrees in wasm
 
+If building from source: 
+
+```
+wasm-pack build --target nodejs --features wasm --no-default-features
+```
+
+then:
+
+```javascript
+import { SubTree } from "../pkg/spacedb.js";
+
+const raw = new Uint8Array(/* proof data */); // or null for an empty subtree
+const subtree = new SubTree(raw);
+
+const root = subtree.compute_root();
+console.log("Root hash:", Buffer.from(root).toString('hex'));
+
+console.log("entries: ", subtree.entries());
+
+```
 
 ## Key Iteration
 

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
 
     // Get the committed snapshot
     let mut snapshot = db.begin_read()?;
-    println!("Tree root: {}", hex::encode(snapshot.root()?));
+    println!("Tree root: {}", hex::encode(snapshot.compute_root()?));
 
     // Prove a subset of the keys
     let keys_to_prove: Vec<_> = (0..10)
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
     let subtree = snapshot.prove(&keys_to_prove, ProofType::Standard)?;
 
     // Will have the exact same root as the snapshot
-    println!("Subtree root: {}", hex::encode(subtree.root().unwrap()));
+    println!("Subtree root: {}", hex::encode(subtree.compute_root().unwrap()));
 
     // Prove inclusion
     assert!(subtree.contains(&db.hash("key0".as_bytes())).unwrap());

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,0 +1,137 @@
+use alloc::boxed::Box;
+use alloc::vec;
+use crate::{EncodeError, Error, NodeHasher, Result};
+use crate::path::{BitLength, Path, PathSegment};
+use crate::subtree::{SubTree, SubTreeNode, ValueOrHash};
+
+const NODE_LEAF: u8 = 0;
+const NODE_INTERNAL: u8 = 1;
+const NODE_HASH: u8 = 2;
+const NODE_NONE: u8 = 3;
+const LEAF_VALUE: u8 = 0;
+const LEAF_HASH: u8 = 1;
+
+pub trait SubTreeEncoder {
+    fn write_to_slice(&self, buf: &mut [u8]) -> Result<usize>;
+    fn from_slice(buf: &[u8]) -> Result<Self> where Self: Sized;
+}
+
+impl<H : NodeHasher> SubTreeEncoder for SubTree<H> {
+    fn write_to_slice(&self, buf: &mut [u8]) -> Result<usize> {
+        let initial_len = buf.len();
+        let remaining = serialize_node(&self.root, buf)?;
+        Ok(initial_len - remaining.len())
+    }
+
+    fn from_slice(mut buf:&[u8]) -> Result<Self> {
+        Ok(Self {
+            root: deserialize_node(&mut buf)?,
+            _marker: Default::default(),
+        })
+    }
+}
+
+/// Serializes a `SubTreeNode` into the provided buffer, advancing the buffer slice.
+fn serialize_node<'a>(node: &SubTreeNode, mut buf: &'a mut [u8]) -> Result<&'a mut [u8]> {
+    match node {
+        SubTreeNode::Leaf { key, value_or_hash } => {
+            buf = write_bytes(buf, &[NODE_LEAF])?;
+            buf = write_bytes(buf, &key.0)?;
+            match value_or_hash {
+                ValueOrHash::Value(value) => {
+                    buf = write_bytes(buf, &[LEAF_VALUE])?;
+                    buf = write_bytes(buf, &[value.len() as u8])?;
+                    buf = write_bytes(buf, value)?;
+                }
+                ValueOrHash::Hash(hash) => {
+                    buf = write_bytes(buf, &[LEAF_HASH])?;
+                    buf = write_bytes(buf, hash)?;
+                }
+            }
+        }
+        SubTreeNode::Internal { prefix, left, right } => {
+            buf = write_bytes(buf, &[NODE_INTERNAL])?;
+            buf = write_bytes(buf, prefix.as_bytes())?;
+            buf = serialize_node(left, buf)?;
+            buf = serialize_node(right, buf)?;
+        }
+        SubTreeNode::Hash(hash) => {
+            buf = write_bytes(buf, &[NODE_HASH])?;
+            buf = write_bytes(buf, hash)?;
+        }
+        SubTreeNode::None => {
+            buf = write_bytes(buf, &[NODE_NONE])?;
+        }
+    }
+    Ok(buf)
+}
+
+/// Deserializes a `SubTreeNode` from the provided buffer, advancing the slice.
+fn deserialize_node(buf: &mut &[u8]) -> Result<SubTreeNode> {
+    let mut tag_buf = [0u8; 1];
+    read_bytes(buf, &mut tag_buf)?;
+    match tag_buf[0] {
+        NODE_LEAF => {
+            let mut key = [0u8; 32];
+            read_bytes(buf, &mut key)?;
+            let mut subtag_buf = [0u8; 1];
+            read_bytes(buf, &mut subtag_buf)?;
+            let value_or_hash = match subtag_buf[0] {
+                LEAF_HASH => {
+                    let mut hash = [0u8; 32];
+                    read_bytes(buf, &mut hash)?;
+                    ValueOrHash::Hash(hash)
+                }
+                LEAF_VALUE => {
+                    let mut len_buf = [0u8; 1];
+                    read_bytes(buf, &mut len_buf)?;
+                    let len = len_buf[0] as usize;
+                    let mut bytes = vec![0u8; len];
+                    read_bytes(buf, &mut bytes)?;
+                    ValueOrHash::Value(bytes)
+                }
+                _ => return Err(Error::Encode(EncodeError::InvalidData("unknown leaf tag"))),
+            };
+            Ok(SubTreeNode::Leaf {
+                key: Path(key),
+                value_or_hash,
+            })
+        }
+        NODE_INTERNAL => {
+            let mut prefix_body = [0u8; 33];
+            read_bytes(buf, &mut prefix_body[..1])?;
+            let byte_count = (prefix_body[0] as usize + 7) / 8;
+            read_bytes(buf, &mut prefix_body[1..byte_count + 1])?;
+            let prefix = PathSegment(prefix_body);
+            let left = Box::new(deserialize_node(buf)?);
+            let right = Box::new(deserialize_node(buf)?);
+            Ok(SubTreeNode::Internal { prefix, left, right })
+        }
+        NODE_HASH => {
+            let mut hash = [0u8; 32];
+            read_bytes(buf, &mut hash)?;
+            Ok(SubTreeNode::Hash(hash))
+        }
+        NODE_NONE => Ok(SubTreeNode::None),
+        _ => Err(Error::Encode(EncodeError::InvalidData("unknown node tag"))),
+    }
+}
+
+fn write_bytes<'a>(buf: &'a mut [u8], data: &[u8]) -> Result<&'a mut [u8]> {
+    if buf.len() < data.len() {
+        return Err(Error::Encode(EncodeError::BufferTooSmall));
+    }
+    let (head, tail) = buf.split_at_mut(data.len());
+    head.copy_from_slice(data);
+    Ok(tail)
+}
+
+fn read_bytes<'a>(buf: &mut &'a [u8], out: &mut [u8]) -> Result<()> {
+    if buf.len() < out.len() {
+        return Err(Error::Encode(EncodeError::BufferTooSmall));
+    }
+    let (head, tail) = buf.split_at(out.len());
+    out.copy_from_slice(head);
+    *buf = tail;
+    Ok(())
+}

--- a/src/subtree.rs
+++ b/src/subtree.rs
@@ -48,7 +48,7 @@ impl<H: NodeHasher> SubTree<H> {
         }
     }
 
-    pub fn root(&self) -> Result<Hash> {
+    pub fn compute_root(&self) -> Result<Hash> {
         if self.is_empty() {
             return Ok(H::hash(&[]));
         }

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -99,7 +99,7 @@ impl<H: NodeHasher> ReadTransaction<H> {
         result
     }
 
-    pub fn root(&mut self) -> Result<Hash> {
+    pub fn compute_root(&mut self) -> Result<Hash> {
         if self.is_empty() {
             return Ok(H::hash(&[]));
         }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,135 @@
+#[cfg(feature = "wasm")]
+mod wasm_api {
+    use alloc::format;
+    use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+    use js_sys::{Array, Uint8Array};
+
+    use crate::{
+        subtree::SubTree as NativeSubTree,
+        encode::SubTreeEncoder,
+        Sha256Hasher,
+    };
+    use crate::subtree::ValueOrHash;
+
+    #[wasm_bindgen]
+    pub struct SubTree {
+        inner: NativeSubTree<Sha256Hasher>,
+    }
+
+    #[wasm_bindgen]
+    impl SubTree {
+        /// Creates a new SubTree.
+        /// If `data` is provided (as a Uint8Array), the subtree is initialized from it;
+        /// if omitted, an empty subtree is created.
+        #[wasm_bindgen(constructor)]
+        pub fn new(data: Option<Uint8Array>) -> Result<SubTree, JsValue> {
+            match data {
+                Some(array) => {
+                    let buf = array.to_vec();
+                    NativeSubTree::from_slice(&buf)
+                        .map(|inner| SubTree { inner })
+                        .map_err(|err| JsValue::from_str(&format!("Deserialization error: {:?}", err)))
+                }
+                None => {
+                    Ok(SubTree {
+                        inner: NativeSubTree::empty(),
+                    })
+                }
+            }
+        }
+
+        /// Serializes the SubTree to a Uint8Array.
+        #[wasm_bindgen]
+        pub fn write(&self, buf: &mut [u8]) -> Result<usize, JsValue> {
+            Ok(self.inner.write_to_slice(buf)
+                .map_err(|err| JsValue::from_str(&format!("Serialization error: {:?}", err)))?)
+        }
+
+        /// Returns the root hash as a Uint8Array.
+        #[wasm_bindgen]
+        pub fn compute_root(&self) -> Result<Uint8Array, JsValue> {
+            self.inner
+                .compute_root()
+                .map(|hash| Uint8Array::from(&hash[..]))
+                .map_err(|err| JsValue::from_str(&format!("Error retrieving root: {:?}", err)))
+        }
+
+        /// Returns true if the subtree is empty.
+        #[wasm_bindgen]
+        pub fn is_empty(&self) -> bool {
+            self.inner.is_empty()
+        }
+
+        /// Returns true if the subtree contains the given key.
+        #[wasm_bindgen]
+        pub fn contains(&self, key: &[u8]) -> Result<bool, JsValue> {
+            if key.len() != 32 {
+                return Err(JsValue::from_str("Invalid key length; expected 32 bytes"));
+            }
+            let mut key_arr = [0u8; 32];
+            key_arr.copy_from_slice(key);
+            self.inner
+                .contains(&key_arr)
+                .map_err(|err| JsValue::from_str(&format!("Contains error: {:?}", err)))
+        }
+
+        /// Inserts a full value associated with the given key.
+        #[wasm_bindgen]
+        pub fn insert_value(&mut self, key: &[u8], value: &[u8]) -> Result<(), JsValue> {
+            if key.len() != 32 {
+                return Err(JsValue::from_str("Invalid key length; expected 32 bytes"));
+            }
+            let mut key_arr = [0u8; 32];
+            key_arr.copy_from_slice(key);
+            self.inner
+                .insert(key_arr, ValueOrHash::Value(value.to_vec()))
+                .map_err(|err| JsValue::from_str(&format!("Insert error: {:?}", err)))
+        }
+
+        /// Inserts a hash associated with the given key.
+        #[wasm_bindgen]
+        pub fn insert_hash(&mut self, key: &[u8], hash: &[u8]) -> Result<(), JsValue> {
+            if key.len() != 32 {
+                return Err(JsValue::from_str("Invalid key length; expected 32 bytes"));
+            }
+            if hash.len() != 32 {
+                return Err(JsValue::from_str("Invalid hash length; expected 32 bytes"));
+            }
+            let mut key_arr = [0u8; 32];
+            key_arr.copy_from_slice(key);
+            let mut hash_arr = [0u8; 32];
+            hash_arr.copy_from_slice(hash);
+            self.inner
+                .insert(key_arr, ValueOrHash::Hash(hash_arr))
+                .map_err(|err| JsValue::from_str(&format!("Insert error: {:?}", err)))
+        }
+
+        /// Deletes the key from the subtree, consuming this subtree and returning a new one.
+        #[wasm_bindgen]
+        pub fn delete(self, key: &[u8]) -> Result<SubTree, JsValue> {
+            if key.len() != 32 {
+                return Err(JsValue::from_str("Invalid key length; expected 32 bytes"));
+            }
+            let mut key_arr = [0u8; 32];
+            key_arr.copy_from_slice(key);
+            self.inner
+                .delete(&key_arr)
+                .map(|new_tree| SubTree { inner: new_tree })
+                .map_err(|err| JsValue::from_str(&format!("Delete error: {:?}", err)))
+        }
+
+        /// Returns an array of [key, value] pairs.
+        /// Each key and value is a Uint8Array.
+        #[wasm_bindgen]
+        pub fn entries(&self) -> Result<Array, JsValue> {
+            let arr = Array::new();
+            for (key, value) in self.inner.iter() {
+                let key_arr = Uint8Array::from(&key[..]);
+                let value_arr = Uint8Array::from(&value[..]);
+                let pair = Array::of2(&key_arr.into(), &value_arr.into());
+                arr.push(&pair.into());
+            }
+            Ok(arr)
+        }
+    }
+}


### PR DESCRIPTION
This PR adds:

1. wasm bindings for subtrees useful for verifying space and utxo inclusion/exclusion proofs
2. More compact serialization/deserialization of subtrees